### PR TITLE
Code cleanup

### DIFF
--- a/funcs.el
+++ b/funcs.el
@@ -11,6 +11,81 @@
 
 (defvar spacemacs--eww-buffers nil)
 
+(defun spacemacs/eww-render-latex ()
+  (interactive)
+  (call-interactively #'texfrag-mode)
+  (when texfrag-mode
+    (eww-reload)))
+
+(defun spacemacs//eww-setup-transient-state ()
+
+  "Setup eww transient state with toggleable help hint.
+
+Beware: due to transient state's implementation details this
+function must be called in the :init section of `use-package' or
+full hint text will not show up!"
+  (defvar spacemacs--eww-ts-full-hint-toggle t
+    "Toggle the state of the eww transient state documentation.")
+
+  (defvar spacemacs--eww-ts-full-hint nil
+    "Display full pdf transient state documentation.")
+
+  (defvar spacemacs--eww-ts-minified-hint nil
+    "Display minified pdf transient state documentation.")
+
+  (defun spacemacs//eww-ts-toggle-hint ()
+    "Toggle the full hint docstring for the eww transient state."
+    (interactive)
+    (setq spacemacs--eww-ts-full-hint-toggle
+          (not spacemacs--eww-ts-full-hint-toggle)))
+
+  (defun spacemacs//eww-ts-hint ()
+    "Return a condensed/full hint for the eww transient state"
+    (concat
+     " "
+     (if spacemacs--eww-ts-full-hint-toggle
+         spacemacs--eww-ts-full-hint
+       (concat "[" (propertize "?" 'face 'hydra-face-red) "] help"))))
+
+  (spacemacs|transient-state-format-hint eww
+    spacemacs--eww-ts-full-hint
+    (format "\n[_?_] toggle help
+ Navigation^^^^                Scale/Fit^^                    Annotations^^       Actions^^           Other^^
+ ----------^^^^--------------- ---------^^------------------  -----------^^------ -------^^---------- -----^^---
+ [_[_/_]_] history back/forw   [_v_] toggle visual-line-mode  [_al_] list         [_t_] toggle latex  [_q_] quit
+ [_H_/_L_] prev/next eww-buff  [_w_] toggle writeroom-mode    ^^                  [_c_] cycle theme
+ ^^^^                          [_+_] zoom-in
+ ^^^^                          [_-_] zoom-out
+ ^^^^                          [_=_] unzoom"))
+
+  (spacemacs|define-transient-state eww
+    :title "Eww Transient State"
+    :hint-is-doc t
+    :dynamic-hint (spacemacs//eww-ts-hint)
+    :on-enter (setq which-key-inhibit t)
+    :on-exit (setq which-key-inhibit nil)
+    :evil-leader-for-mode (eww-mode . ".")
+    :bindings
+    ("?" spacemacs//eww-ts-toggle-hint)
+    ;; Navigation
+    ("["  eww-back-url)
+    ("]"  eww-next-url)
+    ("H"  spacemacs/eww-jump-previous-buffer)
+    ("L"  spacemacs/eww-jump-next-buffer)
+    ;; Scale/Fit
+    ("w"  writeroom-mode)
+    ("v" visual-line-mode)
+    ("+" zoom-frm-in)
+    ("-" zoom-frm-out)
+    ("=" zoom-frm-unzoom)
+    ;; Annotations
+    ("al" pdf-annot-list-annotations :exit t)
+    ;; Actions
+    ("t" spacemacs/eww-render-latex)
+    ("c" spacemacs/cycle-spacemacs-theme)
+    ;; Other
+    ("q" nil :exit t)))
+
 (defun spacemacs//eww-get-buffers ()
   (dolist (buffer (buffer-list))
     (with-current-buffer buffer

--- a/packages.el
+++ b/packages.el
@@ -64,12 +64,11 @@ Each entry is either:
         recipe.  See: https://github.com/milkypostman/melpa#recipe-format")
 
 (defun eww/init-eww ()
-  (progn
-    (dolist (mode '(eww-mode))
-      (eval-after-load "eww"
-        '(progn
-           (define-key eww-link-keymap "f" 'eww-follow-link)
-           (define-key eww-link-keymap "F" (lambda () (interactive) (eww-follow-link 2)))))
+  (with-eval-after-load "eww"
+    (define-key eww-link-keymap "f" 'eww-follow-link)
+    (define-key eww-link-keymap "F" (lambda () (interactive) (eww-follow-link 2)))
+
+    (let ((mode 'eww-mode))
       (spacemacs/declare-prefix-for-mode mode "mv" "view")
       (spacemacs/declare-prefix-for-mode mode "ml" "list")
       (spacemacs/set-leader-keys-for-major-mode mode
@@ -93,13 +92,15 @@ Each entry is either:
         "L" 'eww-forward-url
         (kbd "C-j") 'shr-next-link
         (kbd "C-k") 'shr-previous-link
-        "o" 'ace-link-eww)
-    (dolist (mode '(eww-history-mode))
+        "o" 'ace-link-eww))
+
+    (let ((mode 'eww-history-mode))
       (spacemacs/set-leader-keys-for-major-mode mode
         "f" 'eww-history-browse)
       (evil-define-key 'normal eww-history-mode-map "f" 'eww-history-browse
-        "q" 'quit-window)
-    (dolist (mode '(eww-bookmark-mode))
+        "q" 'quit-window))
+
+    (let ((mode 'eww-bookmark-mode))
       (spacemacs/set-leader-keys-for-major-mode mode
         "d" 'eww-bookmark-kill
         "y" 'eww-bookmark-yank
@@ -108,8 +109,9 @@ Each entry is either:
         "q" 'quit-window
         "f" 'eww-bookmark-browse
         "d" 'eww-bookmark-kill
-        "y" 'eww-bookmark-yank)
-    (dolist (mode '(eww-buffers-mode))
+        "y" 'eww-bookmark-yank))
+
+    (let ((mode 'eww-buffers-mode))
       (spacemacs/set-leader-keys-for-major-mode mode
         "f" 'eww-buffer-select
         "d" 'eww-buffer-kill
@@ -120,6 +122,5 @@ Each entry is either:
         "f" 'eww-buffer-select
         "d" 'eww-buffer-kill
         "n" 'eww-buffer-show-next
-        "p" 'eww-buffer-show-previous)
-      ))))))
+        "p" 'eww-buffer-show-previous))))
 ;;; packages.el ends here

--- a/packages.el
+++ b/packages.el
@@ -33,6 +33,7 @@
   '(
     ;; A local package
     (eww :location built-in)
+    texfrag
     ;; (ace-link :location elpa)
     ;; (helm-net :location elpa)
     )
@@ -123,4 +124,7 @@ Each entry is either:
         "d" 'eww-buffer-kill
         "n" 'eww-buffer-show-next
         "p" 'eww-buffer-show-previous))))
+(defun eww/init-texfrag ()
+  (use-package texfrag
+    :defer t))
 ;;; packages.el ends here

--- a/packages.el
+++ b/packages.el
@@ -3,6 +3,7 @@
 ;; Copyright (c) 2012-2017 Sylvain Benner & Contributors
 ;;
 ;; Author: Colton Kopsa <coljamkop@gmail.com>
+;;         Daniel Nicolai <dalanicolai@gmail.com>
 ;; URL: https://github.com/syl20bnr/spacemacs
 ;;
 ;; This file is not part of GNU Emacs.
@@ -65,65 +66,74 @@ Each entry is either:
         recipe.  See: https://github.com/milkypostman/melpa#recipe-format")
 
 (defun eww/init-eww ()
-  (with-eval-after-load "eww"
-    (define-key eww-link-keymap "f" 'eww-follow-link)
-    (define-key eww-link-keymap "F" (lambda () (interactive) (eww-follow-link 2)))
+  (use-package eww
+    :defer t
+    :init
+    (spacemacs//eww-setup-transient-state)
+    :config
+    (progn
+      (define-key eww-link-keymap "f" 'eww-follow-link)
+      (define-key eww-link-keymap "F" (lambda () (interactive) (eww-follow-link 2)))
 
-    (let ((mode 'eww-mode))
-      (spacemacs/declare-prefix-for-mode mode "mv" "view")
-      (spacemacs/declare-prefix-for-mode mode "ml" "list")
-      (spacemacs/set-leader-keys-for-major-mode mode
-        "s" 'helm-google-suggest
-        "S" 'browse-web
-        "r" 'eww-reload
-        "p" 'eww-previous-url
-        "n" 'eww-next-url
-        "h" 'eww-list-histories
-        "d" 'eww-download
-        "a" 'eww-add-bookmark
-        "lb" 'eww-list-buffers
-        "lo" 'eww-list-bookmarks
-        "vx" 'eww-browse-with-external-browser
-        "vf" 'eww-toggle-fonts
-        "vr" 'eww-readable)
-      (evil-define-key 'normal eww-mode-map
-        "H" 'eww-back-url
-        "J" 'spacemacs/eww-jump-next-buffer
-        "K" 'spacemacs/eww-jump-previous-buffer
-        "L" 'eww-forward-url
-        (kbd "C-j") 'shr-next-link
-        (kbd "C-k") 'shr-previous-link
-        "o" 'ace-link-eww))
+      (let ((mode 'eww-mode))
+        (spacemacs/declare-prefix-for-mode mode "mv" "view")
+        (spacemacs/declare-prefix-for-mode mode "ml" "list")
+        (spacemacs/set-leader-keys-for-major-mode mode
+          "s" 'helm-google-suggest
+          "S" 'browse-web
+          "t" 'spacemacs/eww-render-latex
+          "r" 'eww-reload
+          "p" 'eww-previous-url
+          "n" 'eww-next-url
+          "h" 'eww-list-histories
+          "d" 'eww-download
+          "a" 'eww-add-bookmark
+          "lb" 'eww-list-buffers
+          "lo" 'eww-list-bookmarks
+          "vx" 'eww-browse-with-external-browser
+          "vf" 'eww-toggle-fonts
+          "vr" 'eww-readable)
+        (evil-define-key 'normal eww-mode-map
+          (kbd "C-o") 'eww-back-url
+          (kbd "C-i") 'eww-forward-url
+          "[" 'eww-back-url
+          "]" 'eww-forward-url
+          "L" 'spacemacs/eww-jump-next-buffer
+          "H" 'spacemacs/eww-jump-previous-buffer
+          (kbd "C-j") 'shr-next-link
+          (kbd "C-k") 'shr-previous-link
+          "o" 'ace-link-eww))
 
-    (let ((mode 'eww-history-mode))
-      (spacemacs/set-leader-keys-for-major-mode mode
-        "f" 'eww-history-browse)
-      (evil-define-key 'normal eww-history-mode-map "f" 'eww-history-browse
-        "q" 'quit-window))
+      (let ((mode 'eww-history-mode))
+        (spacemacs/set-leader-keys-for-major-mode mode
+          "f" 'eww-history-browse)
+        (evil-define-key 'normal eww-history-mode-map "f" 'eww-history-browse
+          "q" 'quit-window))
 
-    (let ((mode 'eww-bookmark-mode))
-      (spacemacs/set-leader-keys-for-major-mode mode
-        "d" 'eww-bookmark-kill
-        "y" 'eww-bookmark-yank
-        "f" 'eww-bookmark-browse)
-      (evil-define-key 'normal eww-bookmark-mode-map
-        "q" 'quit-window
-        "f" 'eww-bookmark-browse
-        "d" 'eww-bookmark-kill
-        "y" 'eww-bookmark-yank))
+      (let ((mode 'eww-bookmark-mode))
+        (spacemacs/set-leader-keys-for-major-mode mode
+          "d" 'eww-bookmark-kill
+          "y" 'eww-bookmark-yank
+          "f" 'eww-bookmark-browse)
+        (evil-define-key 'normal eww-bookmark-mode-map
+          "q" 'quit-window
+          "f" 'eww-bookmark-browse
+          "d" 'eww-bookmark-kill
+          "y" 'eww-bookmark-yank))
 
-    (let ((mode 'eww-buffers-mode))
-      (spacemacs/set-leader-keys-for-major-mode mode
-        "f" 'eww-buffer-select
-        "d" 'eww-buffer-kill
-        "n" 'eww-buffer-show-next
-        "p" 'eww-buffer-show-previous)
-      (evil-define-key 'normal eww-buffers-mode-map
-        "q" 'quit-window
-        "f" 'eww-buffer-select
-        "d" 'eww-buffer-kill
-        "n" 'eww-buffer-show-next
-        "p" 'eww-buffer-show-previous))))
+      (let ((mode 'eww-buffers-mode))
+        (spacemacs/set-leader-keys-for-major-mode mode
+          "f" 'eww-buffer-select
+          "d" 'eww-buffer-kill
+          "n" 'eww-buffer-show-next
+          "p" 'eww-buffer-show-previous)
+        (evil-define-key 'normal eww-buffers-mode-map
+          "q" 'quit-window
+          "f" 'eww-buffer-select
+          "d" 'eww-buffer-kill
+          "n" 'eww-buffer-show-next
+          "p" 'eww-buffer-show-previous)))))
+
 (defun eww/init-texfrag ()
   (use-package texfrag
     :defer t))


### PR DESCRIPTION
If you are interested, I did nothing important, just some code cleanup (this new code makes more sense to me)

Replaced `eval-after-load` by `with-eval-after-load`. See answer
[here](https://stackoverflow.com/questions/21880139/what-is-with-eval-after-load-in-emacs-lisp).
Also replaced the `dolist`'s  by `let`'s. That's all...